### PR TITLE
Add tiny-lr as dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "chokidar": "^1.0.0-rc3",
     "colors": "^1.0.3",
-    "minimist": "^1.1.0"
+    "minimist": "^1.1.0",
+    "tiny-lr": "^0.1.5"
   }
 }


### PR DESCRIPTION
I guess you had `tiny-lr` installed globally so perhaps you missed this?

Thanks for putting together this tool though! Exactly what I was looking for.
